### PR TITLE
docs: fix wrong variable in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ the fs utils and default parsers/serializers for simplest possible usage in node
 import rdf from '@zazuko/env-node'
         
 // parse
-const dataset = await env.dataset().import(env.fromFile(`/path/to/data.nt`))
+const dataset = await rdf.dataset().import(rdf.fromFile(`/path/to/data.nt`))
 
 // serialise
-await env.toFile(dataset, `/path/to/data.json`)
+await rdf.toFile(dataset, `/path/to/data.json`)
 ```
 
 ## Extend `@zazuko/env` yourself


### PR DESCRIPTION
The `env` variable seems to be a copy-paste from the lower examples where an environment is extended.
In the first block, we're using `@zazuko/env-node` which we import as `rdf`, not `env`.